### PR TITLE
Fix OperationalMode Pilot

### DIFF
--- a/Invoke-CMApplyDriverPackage.ps1
+++ b/Invoke-CMApplyDriverPackage.ps1
@@ -977,7 +977,7 @@ Process {
 					}
 					else {
 						Write-CMLogEntry -Value " - Querying AdminService for driver package instances" -Severity 1
-						$Packages = Get-AdminServiceItem -Resource "/SMS_Package?`$filter=contains(Name,'$($Filter)')" | Where-Object { $_.PackageName -notmatch "Pilot" -and $_.PackageName -notmatch "Retired" }
+						$Packages = Get-AdminServiceItem -Resource "/SMS_Package?`$filter=contains(Name,'$($Filter)')" | Where-Object { $_.Name -notmatch "Pilot" -and $_.Name -notmatch "Retired" }
 					}
 
                 }
@@ -988,7 +988,7 @@ Process {
 					}
 					else {
 						Write-CMLogEntry -Value " - Querying AdminService for driver package instances" -Severity 1
-						$Packages = Get-AdminServiceItem -Resource "/SMS_Package?`$filter=contains(Name,'$($Filter)')" | Where-Object { $_.PackageName -match "Pilot" }
+						$Packages = Get-AdminServiceItem -Resource "/SMS_Package?`$filter=contains(Name,'$($Filter)')" | Where-Object { $_.Name -match "Pilot" }
 					}
                 }
             }
@@ -1374,7 +1374,7 @@ Process {
 			
 			try {
 				# Attempt to retrieve fallback driver packages from ConfigMgr WebService
-				$FallbackDriverPackages = Get-AdminServiceItem -Resource "/SMS_Package?`$filter=contains(Name,'Driver Fallback Package')" | Where-Object { $_.PackageName -notmatch "Pilot" -and $_.PackageName -notmatch "Retired" }
+				$FallbackDriverPackages = Get-AdminServiceItem -Resource "/SMS_Package?`$filter=contains(Name,'Driver Fallback Package')" | Where-Object { $_.Name -notmatch "Pilot" -and $_.Name -notmatch "Retired" }
 			
 				if ($FallbackDriverPackages -ne $null) {
 					Write-CMLogEntry -Value " - Retrieved a total of '$(($FallbackDriverPackages | Measure-Object).Count)' fallback driver packages from web service matching 'Driver Fallback Package' within the name" -Severity 1


### PR DESCRIPTION
Thanks for the new version 4, it's great to see the script is using AdminService now. 
Pilot mode did not find any driverpackages using AdminService. Found out that the parameter for the name of the driverpackage is not 'PackageName' but 'Name'.

This should fix Pilot mode, but also fix Production mode, so it's not using pilot drivers in production.

Ps. This is my first pull reqest, so i hope i've done everything correct.