### PR TITLE
Get-OSBuild should always return a string

### DIFF
--- a/Invoke-CMApplyDriverPackage.ps1
+++ b/Invoke-CMApplyDriverPackage.ps1
@@ -1004,7 +1004,7 @@ Process {
 		}
 		
 		# Handle return value from function
-		return $OSVersion
+		return [string]$OSVersion
 	}
 	
 	function Get-OSArchitecture {


### PR DESCRIPTION
Fixes an exception in Confirm-OSVersion where the OS version is assumed to be a string and therefore .Replace() fails if version is an integer.
This happens for example if you run a DriverUpdate with OSVersionFallback.