### PR TITLE
Add Windows aliases for TargetOSName parameter re: issue 184

### DIFF
--- a/Invoke-CMApplyDriverPackage.ps1
+++ b/Invoke-CMApplyDriverPackage.ps1
@@ -264,7 +264,7 @@ param(
 	[parameter(Mandatory = $true, ParameterSetName = "Debug")]
 	[parameter(Mandatory = $true, ParameterSetName = "XMLPackage")]
 	[ValidateNotNullOrEmpty()]
-	[ValidateSet("Windows 11", "Windows 10")]
+	[ValidateSet("Windows 11", "Windows11", "Win11", "W11", "Windows 10", "Windows10", "Win10", "W10")]
 	[string]$TargetOSName,
 	
 	[parameter(Mandatory = $true, ParameterSetName = "BareMetal", HelpMessage = "Define the value that will be used as the target operating system version e.g. '2004'.")]
@@ -968,7 +968,7 @@ Process {
 			[string]$OSName	
 		)
 		switch ($OSName) {
-			"Windows 11" {
+			{"Windows 11", "Windows11", "Win11", "W11" -eq $_} {
 				switch (([System.Version]$InputObject).Build) {
 					"22000" {
 						$OSVersion = '21H2'
@@ -982,7 +982,7 @@ Process {
 					}
 				}
 			}
-			"Windows 10" {
+			{"Windows 10", "Windows10", "Win10", "W10" -eq $_} {
 				switch (([System.Version]$InputObject).Build) {
 					"19044" {
 						$OSVersion = '21H2'


### PR DESCRIPTION
There is a minor issue with ConfigMgr when specifying the script Arguments for the "Apply Drivers Dynamically" Task Sequence Step and specifying the new `TargetOSName` attribute. During the script execution, the `"` characters are not respected due to parameter expansion and during the TS execution, the script line ends with`-TargetOSName Windows`. See issue [#184](https://github.com/MSEndpointMgr/ModernDriverManagement/issues/184#issue-1329484524). Experienced this in my environment and added escape characters for this as a workaround but I think this is makes it easier.
I added a wider variety for parameter validation set: "Windows11", "Win11", "W11", "Windows10", "Win10", "W10" and ensured the `Get-OSBuild` switch cases support new parameter sets.
This way people can use more variations of the name without worrying too much about the semantics.