### PR TITLE
Add support for custom driver packages

### DIFF
--- a/Invoke-CMApplyDriverPackage.ps1
+++ b/Invoke-CMApplyDriverPackage.ps1
@@ -1186,6 +1186,11 @@ Process {
 				$ComputerDetails.Model = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
 				$ComputerDetails.SystemSKU = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace root\WMI).BaseBoardProduct.Trim()
 			}
+			default {
+				$ComputerDetails.Manufacturer = $ComputerManufacturer
+				$ComputerDetails.Model = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				$ComputerDetails.SystemSKU = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace root\WMI).BaseBoardProduct.Trim()
+			}
 		}
 		
 		# Handle overriding computer details if debug mode and additional parameters was specified


### PR DESCRIPTION
If a computer manufacturer does not match one of the predefined 10, the Invoke-CMApplyDriverPackage script will fail, even if a custom driver package has been created using the Driver Automation Tool. This default clause will allow custom driver packages to be installed while still allowing for specific handling of different computer manufacturers.

This would fix the issue presented by this pull request #175 