### PR TITLE
Windows 11 25H2, Intel / ASUS NUC, Basic Matching other manufacturers

### DIFF
--- a/Invoke-CMApplyDriverPackage.ps1
+++ b/Invoke-CMApplyDriverPackage.ps1
@@ -277,7 +277,7 @@ param(
 	[parameter(Mandatory = $true, ParameterSetName = "Debug")]
 	[parameter(Mandatory = $false, ParameterSetName = "XMLPackage")]
 	[ValidateNotNullOrEmpty()]
-	[ValidateSet("24H2","23H2","22H2", "21H2", "21H1", "20H2", "2004", "1909", "1903", "1809", "1803", "1709", "1703", "1607")]
+	[ValidateSet("25H2","24H2","23H2","22H2", "21H2", "21H1", "20H2", "2004", "1909", "1903", "1809", "1803", "1709", "1703", "1607")]
 	[string]$TargetOSVersion,
 	
 	[parameter(Mandatory = $false, ParameterSetName = "BareMetal", HelpMessage = "Define the value that will be used as the target operating system architecture e.g. 'x64'.")]
@@ -321,7 +321,7 @@ param(
 	
 	[parameter(Mandatory = $false, ParameterSetName = "Debug", HelpMessage = "Override the automatically detected computer manufacturer when running in debug mode.")]
 	[ValidateNotNullOrEmpty()]
-	[ValidateSet("HP", "Hewlett-Packard", "Dell", "Lenovo", "Microsoft", "Fujitsu", "Panasonic", "Viglen", "AZW", "Getac")]
+	[ValidateSet("HP", "Hewlett-Packard", "Dell", "Lenovo", "Microsoft", "Fujitsu", "Panasonic", "Viglen", "AZW", "Getac", "Intel", "ByteSpeed")]
 	[string]$Manufacturer,
 	
 	[parameter(Mandatory = $false, ParameterSetName = "Debug", HelpMessage = "Override the automatically detected computer model when running in debug mode.")]
@@ -974,10 +974,13 @@ Process {
 		switch ($OSName) {
 			"Windows 11" {
 				switch (([System.Version]$InputObject).Build) {
-        				"26100" {
+					"26200" {
+						$OSVersion = '25H2'
+					}
+        			"26100" {
 						$OSVersion = '24H2'
 					}
-    					"22631" {
+    				"22631" {
 						$OSVersion = '23H2'
 					}
 					"22621" {
@@ -1197,6 +1200,23 @@ Process {
 				$ComputerDetails.Manufacturer = "Getac"
 				$ComputerDetails.Model = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
 				$ComputerDetails.SystemSKU = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace root\WMI).BaseBoardProduct.Trim()
+			}
+			"*Intel*" {
+				$ComputerDetails.Manufacturer = "Intel"
+				$ComputerDetails.Model = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+			}
+			"*ByteSpeed*" {
+				if ($(Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim() -like "*NUC*") {
+					$ComputerDetails.Manufacturer = "Intel"
+					$ComputerDetails.Model = (Get-CIMInstance -ClassName "MS_SystemInformation" -NameSpace root\WMI).BaseBoardProduct.Trim()
+				} else {
+					$ComputerDetails.Manufacturer = "ByteSpeed"
+					$ComputerDetails.Model = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
+				}
+			}
+			Default {
+				$ComputerDetails.Manufacturer = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Manufacturer).Trim()
+				$ComputerDetails.Model = (Get-WmiObject -Class "Win32_ComputerSystem" | Select-Object -ExpandProperty Model).Trim()
 			}
 		}
 		

--- a/Invoke-CMApplyDriverPackage.ps1
+++ b/Invoke-CMApplyDriverPackage.ps1
@@ -112,7 +112,7 @@
     Created:     2017-03-27
     Updated:     2025-09-26
 	
-	Contributors: @CodyMathis123, @JamesMcwatty
+	Contributors: @CodyMathis123, @JamesMcwatty @EdenNelson
     
     Version history:
     1.0.0 - (2017-03-27) - Script created
@@ -210,6 +210,7 @@
 	4.2.2 - (2023-06-23) - Fixed Windows 10 22H2 missing switch value.
  	4.2.3 - (2024-02-06) - Added support for Windows 11 23H2
   	4.2.4 - (2025-01-15) - Added support for Windows 11 24H2
+	4.2.5 - (2025-01-15) - Added support for Windows 11 25H2, added Support for NUC devices from Intel/ASUS w/ ByteSpeed manufacturer. Added basica matching for manufacturer not explicitly supported.
 #>
 [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = "BareMetal")]
 param(

--- a/Invoke-CMApplyDriverPackage.ps1
+++ b/Invoke-CMApplyDriverPackage.ps1
@@ -110,7 +110,7 @@
 	Author:      Nickolaj Andersen / Maurice Daly
     Contact:     @NickolajA / @MoDaly_IT
     Created:     2017-03-27
-    Updated:     2025-01-15
+    Updated:     2025-09-26
 	
 	Contributors: @CodyMathis123, @JamesMcwatty
     


### PR DESCRIPTION
Expanded manufacturer validation and detection to include 'Intel' and 'ByteSpeed'. This Adds support for Intel/ASUS NUC devices. ASUS report ByteSpeed as manufacturer. Also added Default in manufacturer switch statement to attempt basic support/matching for manufacturer not explicitly supported.
Added support for Windows 11 25H2 OS version. 

I have had this manufacture detection code in production for over a year without issue. My fleet includes, HP, Dell, Lenovo, Intel/ASUS NUCs, Misc Gaming  brands for eSports. I feel it's thoroughly tested.